### PR TITLE
Adopt nebula.release plugin v19 after failure to resolve grgit

### DIFF
--- a/build-src/build.gradle.kts
+++ b/build-src/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation("org.owasp:dependency-check-gradle:latest.release")
     implementation("com.netflix.nebula:gradle-contacts-plugin:6.0.0")
     implementation("com.netflix.nebula:gradle-info-plugin:11.3.3")
-    implementation("com.netflix.nebula:nebula-release-plugin:16.0.0")
+    implementation("com.netflix.nebula:nebula-release-plugin:19.0.10")
     implementation("com.netflix.nebula:nebula-publishing-plugin:18.4.0")
     implementation("com.netflix.nebula:nebula-project-plugin:9.6.3")
     implementation("io.github.gradle-nexus:publish-plugin:1.0.0")

--- a/build-src/src/main/kotlin/org.openrewrite.root-project.gradle.kts
+++ b/build-src/src/main/kotlin/org.openrewrite.root-project.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("org.openrewrite.base")
-    id("nebula.release")
+    id("com.netflix.nebula.release")
     id("io.github.gradle-nexus.publish-plugin")
 }
 


### PR DESCRIPTION
## What's changed?
Move from v16 and different groupId to v19
- https://plugins.gradle.org/plugin/nebula.release
- https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v17.0.0
- https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v18.0.0
- https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v19.0.0

## What's your motivation?
```
    > Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.ajoberstar.grgit:grgit-core:4.0.2.
    > Searched in the following locations:
    >   - file:/home/tim/.m2/repository/org/ajoberstar/grgit/grgit-core/4.0.2/grgit-core-4.0.2.pom
    >   - https://repo.maven.apache.org/maven2/org/ajoberstar/grgit/grgit-core/4.0.2/grgit-core-4.0.2.pom
    >   - https://plugins.gradle.org/m2/org/ajoberstar/grgit/grgit-core/4.0.2/grgit-core-4.0.2.pom
    > Required by:
    >     project : > project :build-src > com.netflix.nebula:nebula-release-plugin:16.0.0
    > 
    > 
    > BUILD FAILED in 12s
```