### PR TITLE
Suppress CVE-2024-25712 on rewrite-openapi

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -18,6 +18,16 @@
     </suppress>
     <suppress until="2026-05-01Z">
         <notes><![CDATA[
+       False positive. CVE-2024-25712 is about the Go http-swagger package (XSS via
+       httpSwagger.WrapHandler), not the Java rewrite-openapi library. The scanner is
+       matching on the "swagger"/"openapi" name in the artifact.
+       Added: 2026-04-22
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
+        <cve>CVE-2024-25712</cve>
+    </suppress>
+    <suppress until="2026-05-01Z">
+        <notes><![CDATA[
        file name: quarkus-update-recipes-1.9.0.jar
        ]]></notes>
         <cve>CVE-2022-21724</cve>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1047

## Summary

`CVE-2024-25712` is about the Go `http-swagger` package (XSS via `httpSwagger.WrapHandler`), not the Java `rewrite-openapi` library. The dependency-check scanner matches on the `swagger`/`openapi` name in the artifact.

The shared suppression already exists in `rewrite-build-gradle-plugin/src/main/resources/suppressions.xml`, but `rewrite-recipe-bom` uses `org.openrewrite.root-project` and does not inherit it. This PR adds a packageUrl-scoped local suppression with a `2026-05-01Z` expiry so it gets re-evaluated by the monthly cleanup.

## Test plan
- [x] `xmllint --noout suppressions.xml` passes.