### PR TITLE
Renew false-positive suppressions to 2026-06-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
        file name: rewrite-jenkins-0.35.0-SNAPSHOT.jar
        sev: HIGH
@@ -10,13 +10,13 @@
         <cve>CVE-2022-34792</cve>
         <cve>CVE-2022-34794</cve>
     </suppress>
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
        file name: rewrite-openapi-0.31.0-SNAPSHOT.jar
        ]]></notes>
         <cve>CVE-2022-24863</cve>
     </suppress>
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
        False positive. CVE-2024-25712 is about the Go http-swagger package (XSS via
        httpSwagger.WrapHandler), not the Java rewrite-openapi library. The scanner is
@@ -26,7 +26,7 @@
        <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2024-25712</cve>
     </suppress>
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
        file name: quarkus-update-recipes-1.9.0.jar
        ]]></notes>


### PR DESCRIPTION
## Summary

Suppressions for rewrite-jenkins, rewrite-openapi, and quarkus-update-recipes all expired on 2026-05-01, causing previously-triaged false positives to flag again on this BOM repo. Renewed every entry to \`until=\"2026-06-01Z\"\`. No new entries, no scope changes.

The reasoning is unchanged:
- rewrite-jenkins → CVEs are for Jenkins core plugins, not the recipe jar
- rewrite-openapi → Go http-swagger CPE mismatch
- quarkus-update-recipes → recipe references only, not the vulnerable Quarkus runtime

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1054

## Test plan
- [x] xmllint validates suppressions.xml
- [ ] Next dependency-check scan no longer flags these CVEs in rewrite-recipe-bom