### PR TITLE
Suppress CVE-2026-39852 (false positive: quarkus-update-recipes)

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -67,4 +67,16 @@
         <cve>CVE-2020-8908</cve>
         <cve>CVE-2023-0481</cve>
     </suppress>
+    <suppress until="2026-06-01Z">
+        <notes><![CDATA[
+       False positive. CVE-2026-39852 (GHSA-rc95-pcm8-65v9) is an authorization bypass
+       in io.quarkus:quarkus-vertx-http via matrix parameters in HTTP path normalization.
+       quarkus-update-recipes is an OpenRewrite recipe JAR for migrating Quarkus apps and
+       does not contain or use the vulnerable quarkus-vertx-http runtime. CPE name match
+       on "quarkus" only.
+       Added: 2026-05-13
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-update-recipes@.*$</packageUrl>
+        <cve>CVE-2026-39852</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Adds an OWASP suppression for **CVE-2026-39852** ([GHSA-rc95-pcm8-65v9](https://github.com/quarkusio/quarkus/security/advisories/GHSA-rc95-pcm8-65v9), HIGH).

The CVE is an authorization bypass in `io.quarkus:quarkus-vertx-http` — matrix parameters (semicolons) in HTTP request paths bypass security constraints because the security layer reads the raw path while RESTEasy Reactive strips matrix parameters before routing.

The flagged artifact `io.quarkus:quarkus-update-recipes@1.10.1` is an OpenRewrite recipe JAR for migrating Quarkus apps. It does not contain or use the vulnerable `quarkus-vertx-http` runtime — CPE name match on "quarkus" only. The same artifact already has a long-standing block of similar false-positive suppressions in this file.

Suppression expires `2026-06-01Z` (aligns with monthly cleanup convention) and uses a `packageUrl` regex targeted at `io.quarkus:quarkus-update-recipes` so other Quarkus artifacts are unaffected.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1069

## Test plan

- [x] `xmllint --noout suppressions.xml` passes