### PR TITLE
Suppress CVE-2026-42582 CPE false positive on netty 4.1.x non-http3 modules

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -79,4 +79,16 @@
        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-update-recipes@.*$</packageUrl>
         <cve>CVE-2026-39852</cve>
     </suppress>
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+       False positive. CVE-2026-42582 (GHSA-2c5c-chwr-9hqw) is an unbounded byte[] allocation
+       in QPACK literal decoding, scoped to io.netty:netty-codec-http3 <= 4.2.12.Final
+       (patched in 4.2.13.Final). The flagged artifacts here are on the 4.1.x line and none
+       of them is netty-codec-http3, so the HTTP/3 codec is not present. CPE match on the
+       "netty" group only.
+       Added: 2026-05-27
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@4\.1\..*$</packageUrl>
+        <cve>CVE-2026-42582</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Adds an OWASP DC suppression for `CVE-2026-42582` (GHSA-2c5c-chwr-9hqw) matched against the netty 4.1.133.Final transitive jars in this repo.

The real vulnerability is an unbounded `byte[]` allocation in QPACK literal decoding, scoped to `io.netty:netty-codec-http3 <= 4.2.12.Final` (patched in 4.2.13.Final). The artifacts flagged by the scan — `netty-buffer`, `netty-codec`, `netty-codec-http`, `netty-codec-http2`, `netty-common`, `netty-handler`, `netty-resolver`, `netty-transport`, `netty-transport-classes-epoll`, `netty-transport-native-unix-common` — are all on the 4.1.x line and none is `netty-codec-http3`, so the HTTP/3 codec is not present at all. The scanner is matching on the "netty" group only.

Suppression is scoped via `packageUrl` regex to `io.netty/netty-*@4.1.*` so it does not hide future findings on 4.2.x or on `netty-codec-http3`.

Expiry: `2026-07-01Z` per the 2-week-on-1st-of-month suppression policy.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1080