### PR TITLE
Renew expired OWASP suppressions to 2026-07-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        file name: rewrite-jenkins-0.35.0-SNAPSHOT.jar
        sev: HIGH
@@ -10,13 +10,13 @@
         <cve>CVE-2022-34792</cve>
         <cve>CVE-2022-34794</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        file name: rewrite-openapi-0.31.0-SNAPSHOT.jar
        ]]></notes>
         <cve>CVE-2022-24863</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        False positive. CVE-2024-25712 is about the Go http-swagger package (XSS via
        httpSwagger.WrapHandler), not the Java rewrite-openapi library. The scanner is
@@ -26,7 +26,7 @@
        <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2024-25712</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        file name: quarkus-update-recipes-1.9.0.jar
        ]]></notes>
@@ -67,7 +67,7 @@
         <cve>CVE-2020-8908</cve>
         <cve>CVE-2023-0481</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        False positive. CVE-2026-39852 (GHSA-rc95-pcm8-65v9) is an authorization bypass
        in io.quarkus:quarkus-vertx-http via matrix parameters in HTTP path normalization.


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1085

The false-positive suppressions in this file expired on 2026-06-01 and resurfaced in the 2026-06-03 OpenRewrite vulnerability report. Renewing all of them to `2026-07-01Z`:
- `quarkus-update-recipes` CVE list + `CVE-2026-39852` — CRITICAL (recipe JAR for migrating Quarkus apps; does not contain the vulnerable Quarkus runtime — CPE name match only)
- `CVE-2022-34793/2/4` (rewrite-jenkins), `CVE-2022-24863` / `CVE-2024-25712` (rewrite-openapi) — name-match false positives

All entries now land on a single `2026-07-01Z` expiry so they're cleaned up together.