### PR TITLE
Don't manage versions already managed by the imported rewrite-bom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,11 +28,7 @@ dependencies {
     api("org.openrewrite.maven:rewrite-maven-plugin:$latest")
 
     api("org.openrewrite:rewrite-cobol:$latest")
-    api("org.openrewrite:rewrite-csharp:$latest")
-    api("org.openrewrite:rewrite-docker:$latest")
-    api("org.openrewrite:rewrite-javascript:$latest")
     api("org.openrewrite:rewrite-polyglot:$latest")
-    api("org.openrewrite:rewrite-python:$latest")
     api("org.openrewrite:rewrite-templating:$latest")
 
     api("org.openrewrite.meta:rewrite-analysis:$latest")


### PR DESCRIPTION
Removes the `rewrite-csharp`, `rewrite-docker`, `rewrite-javascript`, and `rewrite-python` dependencies from this BOM. These artifacts are already version-managed by the imported `org.openrewrite:rewrite-bom`, so managing them again here is redundant and risks version drift.