### PR TITLE
Publish rewrite-recipe-bom to the Code Genome Project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.openrewrite.root-project")
     id("org.openrewrite.maven-publish")
     id("org.openrewrite.build.bom-alignment") version("latest.release")
+    id("org.openrewrite.build.publish-cgp") version("latest.release")
 }
 
 configurations.all {


### PR DESCRIPTION
### What's changed?

`build.gradle.kts` now applies `org.openrewrite.build.publish-cgp` alongside the existing publishing conventions, so `publish` uploads to the Code Genome Project's S3 bucket in addition to Sonatype.

### What's your motivation?

- Following openrewrite/rewrite#8356: `org.openrewrite.recipe:rewrite-recipe-bom` is absent from CGP's Maven repository, which its gateway signals with a 422 rather than the 401 it returns for artifacts that exist but need auth:

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://artifacts.codegenomeproject.org/maven/<path>/<version>/maven-metadata.xml
org/openrewrite/rewrite-core              8.89.0-SNAPSHOT -> 401 (present)
org/openrewrite/recipe/rewrite-spring     6.37.0-SNAPSHOT -> 401 (present)
org/openrewrite/recipe/rewrite-recipe-bom 3.36.0-SNAPSHOT -> 422 (absent)
```

- This repository does not use `rewrite-build-gradle-plugin`'s publishing conventions — `build-src/src/main/kotlin/org.openrewrite.maven-publish.gradle.kts` wires up nebula publishing and `gradle-nexus.publish-plugin` directly, and neither knows about CGP. The `cgp_aws_*` secrets are already forwarded to both workflows (#56 and 10c5366), so the credentials were reaching the build and going unused; this change is what consumes them.

- Note that openrewrite/rewrite#8356's description cites `rewrite-recipe-bom` returning 401 as evidence that pom-only artifacts index fine on the CGP side. That particular claim is inaccurate — as shown above, this BOM was never published there either. The conclusion still holds, and once this lands we get real confirmation that a `java-platform` publication indexes correctly.

### Anything in particular you'd like reviewers to focus on?

Verified that the platform publication is covered by the added repository, and that the plugin stays inert without credentials so local builds and forks are unaffected:

```
$ AWS_ACCESS_KEY_ID=test-key AWS_SECRET_ACCESS_KEY=test-secret AWS_REGION=us-west-2 ./gradlew publish --dry-run
:publishNebulaPublicationToCgpRepository SKIPPED
:publishNebulaPublicationToSonatypeRepository SKIPPED

$ env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY ./gradlew publish --dry-run
:publishNebulaPublicationToSonatypeRepository SKIPPED   # no Cgp task registered
```

After this merges and a snapshot publishes, `rewrite-recipe-bom` should return 401 rather than 422.