### PR TITLE
Manage org.openrewrite.tools:jgit-gpg-bc in the BOM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     api("org.openrewrite.recipe:rewrite-static-analysis:$latest")
     api("org.openrewrite.recipe:rewrite-testing-frameworks:$latest")
     api("org.openrewrite.recipe:rewrite-third-party:$latest")
+
+    api("org.openrewrite.tools:jgit-gpg-bc:$latest")
 }
 
 publishing {


### PR DESCRIPTION
## Background / problem
`org.openrewrite.tools:jgit-gpg-bc` is published to Code Genome Project alongside the other OpenRewrite artifacts, but it isn't managed by this BOM. Consumers that need it (the Moderne CLI uses it for GPG-signed commits, and anything else building on the OpenRewrite jgit fork with signing support has the same need) have to pin its version out of band instead of inheriting it from the BOM like the rest of the ecosystem. This also matters for enterprise environments that drive their artifact allowlists from the BOM's managed dependencies.

## Solution
Add `org.openrewrite.tools:jgit-gpg-bc` to the platform's managed dependencies, using the same `$latest` convention as the other entries.
