### PR TITLE
Exclude jgit from checkBomAlignment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,12 @@ configurations.all {
     resolutionStrategy.cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
 }
 
+// rewrite-core pins an older jgit than the one jgit-gpg-bc pulls in; that lag is expected between
+// jgit releases and would otherwise block every publish, so keep jgit out of the alignment check only.
+configurations.named("resolveApi") {
+    exclude(group = "org.openrewrite.tools", module = "jgit")
+}
+
 javaPlatform {
     allowDependencies()
 }


### PR DESCRIPTION
- `checkBomAlignment` fails because `org.openrewrite:rewrite-core` requests `org.openrewrite.tools:jgit:1.4.2` while `org.openrewrite.tools:jgit-gpg-bc` (managed here since #59) brings in `1.5.0-SNAPSHOT`. Since the bom-alignment plugin has no exclude DSL, this excludes jgit from the `resolveApi` configuration the check resolves, which scopes the exclusion to the check alone.

Verified `./gradlew checkBomAlignment` now passes and the generated `pom-default.xml` is unchanged — jgit itself was only ever transitive, never managed by this BOM.