### PR TITLE
Suppress CVE-2023-33202: PEMParser unreachable from jgit-gpg-bc

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -208,4 +208,33 @@
         <cve>CVE-2026-54514</cve>
         <cve>CVE-2026-54515</cve>
     </suppress>
+    <suppress until="2026-11-01Z">
+        <notes><![CDATA[
+       CVE-2023-33202 (GHSA-wjxj-5m7g-mg7q, MODERATE, CVSS 5.5) is a denial of service in
+       org.bouncycastle.openssl.PEMParser: parsing an OpenSSL PEM stream with crafted ASN.1
+       data raises an OutOfMemoryError. Fixed in Bouncy Castle 1.73.
+       Not reachable. These jars arrive on one path only:
+         rewrite-recipe-bom
+         └── org.openrewrite.tools:jgit-gpg-bc:1.5.0-SNAPSHOT
+             └── org.bouncycastle:bc{pg,pkix,prov,util}-jdk15on:1.70
+       jgit-gpg-bc reads local GnuPG keyrings to sign commits. It imports only the OpenPGP,
+       keybox, bcpg packet, ASN.1 and EC APIs (org.bouncycastle.openpgp.*,
+       org.bouncycastle.gpg.keybox.*, org.bouncycastle.bcpg.*); it never references
+       org.bouncycastle.openssl, so PEMParser is never constructed and no OpenSSL PEM
+       stream is ever parsed.
+       Not a version bump: the -jdk15on release line ended at 1.70 and the fix landed only
+       on the -jdk18on line, so remediation means swapping artifact coordinates. That swap
+       compiles only up to 1.78.1 — from 1.79 onwards PBESecretKeyDecryptor.recoverKeyData
+       changed signature for OpenPGP v6 AEAD support — and 1.78.1 is itself inside newer
+       Bouncy Castle advisory ranges (GHSA-574f-3g2m-x479 fixed in 1.80.2,
+       GHSA-cj8j-37rh-8475 and GHSA-c3fc-8qff-9hwx fixed in 1.84). Reaching a clean 1.85
+       requires porting the upstream Eclipse JGit refactor that drops the fork's local
+       SExprParser / SXprUtils / OCBPBEProtectionRemoverFactory in favour of Bouncy Castle's
+       own org.bouncycastle.gpg.SExprParser. Tracked against openrewrite/jgit; re-evaluate
+       once jgit-gpg-bc is on bc*-jdk18on.
+       Added: 2026-08-10
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bc(pg|pkix|prov|util)-jdk15on@.*$</packageUrl>
+        <cve>CVE-2023-33202</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1144

`bcpg-jdk15on`, `bcpkix-jdk15on`, `bcprov-jdk15on` and `bcutil-jdk15on` 1.70 are flagged by [CVE-2023-33202](https://nvd.nist.gov/vuln/detail/CVE-2023-33202) / [GHSA-wjxj-5m7g-mg7q](https://github.com/advisories/GHSA-wjxj-5m7g-mg7q) (MODERATE, CVSS 5.5).

Advisory text, verbatim:

> Bouncy Castle for Java before 1.73 contains a potential Denial of Service (DoS) issue within the Bouncy Castle `org.bouncycastle.openssl.PEMParser` class. This class parses OpenSSL PEM encoded streams containing X.509 certificates, PKCS8 encoded keys, and PKCS7 objects. Parsing a file that has crafted ASN.1 data through the PEMParser causes an OutOfMemoryError, which can enable a denial of service attack.

1.70 is genuinely within the affected range — this is not a CPE false positive.

## Why it is not reachable

The jars arrive on exactly one path (from `includedBy` in the dependency-check report):

```
rewrite-recipe-bom
└── org.openrewrite.tools:jgit-gpg-bc:1.5.0-SNAPSHOT
    └── org.bouncycastle:bc{pg,pkix,prov,util}-jdk15on:1.70
```

`jgit-gpg-bc` reads local GnuPG keyrings to sign commits. Its full set of Bouncy Castle imports is confined to the OpenPGP, keybox, bcpg packet, ASN.1 and EC APIs (`org.bouncycastle.openpgp.*`, `org.bouncycastle.gpg.keybox.*`, `org.bouncycastle.bcpg.*`, `org.bouncycastle.asn1.*`, `org.bouncycastle.math.ec.*`). It never references `org.bouncycastle.openssl`, so `PEMParser` is never constructed and no OpenSSL PEM stream is ever parsed:

```
$ grep -rn "PEMParser\|bouncycastle.openssl" jgit-gpg-bc/src/
(no matches)
```

## Why this is not a version bump

The `-jdk15on` release line ended at 1.70; the fix landed only on `-jdk18on` (1.73+), so remediating means swapping artifact coordinates in `openrewrite/jgit`, not raising a version. I tested that swap against `openrewrite/jgit@3dba293`:

| BC version | `:jgit-gpg-bc:compileJava` |
| --- | --- |
| 1.73 | pass |
| 1.78.1 | pass |
| 1.79 / 1.80 / 1.81 / 1.85 | fail |

From 1.79 onwards `PBESecretKeyDecryptor.recoverKeyData` gained the OpenPGP v6 AEAD parameters, so the fork's `OCBPBEProtectionRemoverFactory` no longer overrides it. Stopping at 1.78.1 is not good enough either — it sits inside `GHSA-574f-3g2m-x479` (CRITICAL, fixed 1.80.2), `GHSA-cj8j-37rh-8475` (HIGH, fixed 1.84) and `GHSA-c3fc-8qff-9hwx` (MODERATE, fixed 1.84), and moving to the `-jdk18on` coordinates is exactly what would make those advisories match by purl. So a partial bump likely trades one MODERATE for a CRITICAL and a HIGH.

Reaching a clean 1.85 (what upstream Eclipse JGit is on today) means porting the upstream refactor that deletes `SExprParser` (826 lines), `SXprUtils` (110) and `OCBPBEProtectionRemoverFactory` and rewrites `SecretKeys` (597 → 153 lines) against Bouncy Castle's own `org.bouncycastle.gpg.SExprParser`. That is a real change to commit-signing code in a module with no tests in the fork, so it belongs in its own `openrewrite/jgit` PR rather than here.

Suppressed until 2026-11-01 and scoped to the four `-jdk15on` artifacts and this CVE, so it lifts automatically once `jgit-gpg-bc` moves to `bc*-jdk18on`.

`xmllint --noout suppressions.xml` passes.
