### PR TITLE
Resolve dependencies from the Code Genome Project

### DIFF
--- a/build-src/src/main/kotlin/org.openrewrite.base.gradle.kts
+++ b/build-src/src/main/kotlin/org.openrewrite.base.gradle.kts
@@ -11,16 +11,6 @@ plugins {
 group = "org.openrewrite"
 description = "Eliminate tech-debt. Automatically."
 
-repositories {
-    if (!project.hasProperty("releasing")) {
-        mavenLocal()
-        maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        }
-    }
-    mavenCentral()
-}
-
 configure<ContactsExtension> {
     val j = Contact("team@moderne.io")
     j.moniker("Moderne")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-platform`
+    id("org.openrewrite.build.recipe-repositories") version("latest.release")
     id("org.openrewrite.root-project")
     id("org.openrewrite.maven-publish")
     id("org.openrewrite.build.bom-alignment") version("latest.release")


### PR DESCRIPTION
The BOM has published to CGP since #57 and both `ci.yml` and `publish.yml` forward `cgp_artifacts_maven_username` / `cgp_artifacts_maven_token`. But `org.openrewrite.base.gradle.kts` hand-rolled a `repositories` block with only mavenLocal, Sonatype snapshots and Maven Central, so the credentials arrived unused and nothing resolved from CGP.

Apply `org.openrewrite.build.recipe-repositories` and delete the block it supersedes. CGP is group-scoped to `org.openrewrite` and `io.moderne`, so an outage or expired token can't break resolution of anything else.

CGP resolves last until rewrite-build-gradle-plugin #206 ships — `latest.release` is v2.21.1 today. No change needed here when it does.

moderneinc/moderne-recipe-bom has the identical gap.