### PR TITLE
Drop rewrite-codemods from the BOM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
 
     api("org.openrewrite.recipe:rewrite-all:$latest")
     api("org.openrewrite.recipe:rewrite-apache:$latest")
-    api("org.openrewrite.recipe:rewrite-codemods:$latest")
     api("org.openrewrite.recipe:rewrite-cucumber-jvm:$latest")
     api("org.openrewrite.recipe:rewrite-feature-flags:$latest")
     api("org.openrewrite.recipe:rewrite-github-actions:$latest")


### PR DESCRIPTION
The `v3.37.0` publish failed at `:checkBomAlignment` because `rewrite-codemods:0.27.2` still requests rewrite `8.88.0` while every other module in the BOM is on `8.89.0`:

```
org.openrewrite:rewrite-core
  8.88.0 requested by:
    org.openrewrite.recipe:rewrite-codemods:0.27.2
  8.89.0 requested by:
    <everything else>
```

Rather than cutting a codemods release to realign, drop it from the BOM. `:checkBomAlignment` passes locally with `-Preleasing` after this change.

The failed `v3.37.0` GitHub release and tag have been deleted; nothing was published to Maven Central (`3.37.0` returns 404), so `v3.37.0` can be re-tagged once this merges.

Note: `rewrite-codemods-ng` was never managed by this BOM — it is absent from `build.gradle.kts` and from the published `3.36.0` pom, so there was nothing to remove for it.