### PR TITLE
Run the scheduled build after the repos it aggregates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - main
   workflow_dispatch: {}
   schedule:
-    - cron: 0 16 * * *
+    - cron: 0 20 * * *
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Problem

This BOM resolves every member at `latest.integration`, so it has to run *after* those repos publish their snapshots. It was scheduled at `0 16` — the same slot as `openrewrite/rewrite`, and one to two hours **ahead of every member it aggregates**.

The rest of the ecosystem is already tiered by dependency depth; only the two BOMs were left in the earliest tier:

| cron | repos |
|---|---|
| `0 16` | `openrewrite/rewrite` |
| `0 17` | rewrite-templating, migrate-java, static-analysis, testing-frameworks, java-dependencies, prethink, rewrite-rewrite, … |
| `0 18` | rewrite-spring, rewrite-analysis, github-actions, jackson, logging-frameworks, rewrite-all, quarkus, micronaut, polyglot |
| `0 16` | **rewrite-recipe-bom** ← wrong tier |

## Why it matters

Running early is harmless mid-cycle, because yesterday's snapshot is still a valid `latest.integration` candidate. It is *not* harmless in the days after a release: once `3.37.0` shipped on Aug 12, `latest.integration` had no `3.38.0-SNAPSHOT` to prefer and fell back to the release, which pins the entire previous line (`rewrite-bom 8.89.0`, `rewrite-analysis 2.37.1`, …). That is what `checkBomAlignment` reports.

## Why `0 20` and not `0 19`

Scheduled runs queue for a long time, so the tiers overlap more than the cron times suggest. Recent observed dispatch and finish times:

| tier | dispatched | finished |
|---|---|---|
| `0 16` | 16:14–16:15 | 16:20–16:27 |
| `0 17` | 17:17–17:58 | 17:23–18:07 |
| `0 18` | 18:20–19:02 | 18:43–19:20 |

A literal one-hour step to `0 19` would still collide: `rewrite-quarkus` was dispatched at 19:02 and `rewrite-spring` finished at 19:20. `0 20` clears the observed tail with room to spare, and this build only takes 3–5 minutes.

`moderneinc/moderne-recipe-bom`, which consumes this BOM, moves to `0 21` in a companion PR.