### PR TITLE
Drop the Gradle Plugin Portal repository so org.openrewrite:plugin resolves from CGP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ javaPlatform {
 
 group = "org.openrewrite.recipe"
 
-repositories {
-    gradlePluginPortal()
-}
-
 val latest = if (project.hasProperty("releasing")) "latest.release" else "latest.integration"
 dependencies {
     api(platform("org.openrewrite:rewrite-bom:$latest"))


### PR DESCRIPTION
`main` CI has been failing `checkBomAlignment` on:

```
org.openrewrite:rewrite-bom
  8.89.0 requested by:
    org.openrewrite:plugin:7.39.0
  8.91.0-SNAPSHOT requested by:
    ... everything else
```

The Gradle plugin now publishes snapshots to the Code Genome Project (`org/openrewrite/plugin/7.40.0-SNAPSHOT/`), but `gradlePluginPortal()` was still declared here, and it shadows them: with the portal present, `latest.integration` for `org.openrewrite:plugin` resolves to the portal's `7.39.0` release rather than CGP's `7.40.0-SNAPSHOT`. Reproduced locally against the same repository set — with the portal declared it resolves `7.39.0`, without it `7.40.0-SNAPSHOT`.

The portal was only ever added (c5df800) so the Gradle plugin's version could be resolved at all; every other coordinate here comes from CGP or Maven Central via `org.openrewrite.build.recipe-repositories`, so dropping it costs nothing.

Note that CGP has no `org.openrewrite:plugin` *release* yet, only the snapshot, so a `-Preleasing` build of the BOM needs the Gradle plugin released to CGP first — same as every other coordinate in the BOM.

- For https://github.com/moderneinc/customer-requests/issues/2788