### PR TITLE
Stop publishing to Maven Central

### DIFF
--- a/build-src/build.gradle.kts
+++ b/build-src/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation("com.netflix.nebula.release:com.netflix.nebula.release.gradle.plugin:latest.release")
     implementation("com.netflix.nebula:nebula-publishing-plugin:latest.release")
     implementation("com.netflix.nebula:nebula-project-plugin:latest.release")
-    implementation("io.github.gradle-nexus:publish-plugin:latest.release")
 }
 
 java {

--- a/build-src/src/main/kotlin/org.openrewrite.root-project.gradle.kts
+++ b/build-src/src/main/kotlin/org.openrewrite.root-project.gradle.kts
@@ -1,16 +1,11 @@
 plugins {
     id("org.openrewrite.base")
     id("com.netflix.nebula.release")
-    id("io.github.gradle-nexus.publish-plugin")
 }
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
+tasks.register("closeAndReleaseSonatypeStagingRepository") {
+    group = "publishing"
+    description = "No-op stand-in for the task the Nexus plugin used to contribute, which gh-automation's publish-gradle.yml still invokes by name. Artifacts publish to the Code Genome Project, not Maven Central."
 }
 
 configure<nebula.plugin.release.git.base.ReleasePluginExtension> {


### PR DESCRIPTION
## Background / problem

- openrewrite/rewrite-build-gradle-plugin#220 retired Maven Central publishing for every module built with the shared conventions, so the 8.91.0 release of `rewrite-bom` and all the recipe modules went to the Code Genome Project only. This repository does not use those conventions for its root project; its own `build-src` applies `io.github.gradle-nexus.publish-plugin` with a Sonatype configuration, which is why `rewrite-recipe-bom` 3.38.0 still landed on Maven Central today. That leaves a BOM on Central whose managed artifacts cannot be resolved from Central, which is worse than no BOM at all.

## Solution

- Drops the Nexus publish plugin and its Sonatype configuration from `org.openrewrite.root-project`, and registers the same no-op `closeAndReleaseSonatypeStagingRepository` stand-in that #220 added to `RewriteRootProjectPlugin`, since `gh-automation`'s `publish-gradle.yml` still invokes that task by name until 2026-09-08. The `sonatype_*` secrets in `ci.yml` and `publish.yml` are left as they are, matching how the other repositories were migrated; they can go once `gh-automation` drops the inputs.

## Test plan

- [x] `./gradlew publish closeAndReleaseSonatypeStagingRepository --dry-run -Preleasing` with CGP credentials in the environment schedules only `publishNebulaPublicationToCgpRepository`, `publish` and the no-op stand-in; no Sonatype tasks remain
- [ ] Next release lands on the Code Genome Project and not on Maven Central
