### PR TITLE
Suppress apache:camel CPE over-match on camel-upgrade-recipes

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -143,6 +143,22 @@
        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-update-recipes@.*$</packageUrl>
         <cve>CVE-2026-50559</cve>
     </suppress>
+    <suppress until="2026-10-01Z">
+        <notes><![CDATA[
+       file name: rewrite-third-party-0.47.0-SNAPSHOT.jar (shaded: camel-upgrade-recipes 4.21.0)
+       False positive. Reference only. org.apache.camel.upgrade:camel-upgrade-recipes is the
+       OpenRewrite recipe artifact for migrating user code between Camel versions and ships no
+       Camel runtime. Its version tracks Camel releases, so the apache:camel CPE numerically
+       over-matches it. Suppressed by CPE rather than per-CVE so the next Camel batch stays
+       quiet too. Mirrors the block in rewrite-build-gradle-plugin, whose shared suppression
+       file this repo does not inherit.
+       Reported upstream as dependency-check/DependencyCheck#8780; expires 2026-10-01 to
+       re-check whether that landed.
+       Added: 2026-09-01
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.camel\.upgrade/camel-upgrade-recipes@.*$</packageUrl>
+        <cpe>cpe:/a:apache:camel</cpe>
+    </suppress>
     <suppress>
         <notes><![CDATA[
        False positive. CVE-2009-2475, CVE-2009-2476, CVE-2009-2676, CVE-2009-2689,


### PR DESCRIPTION
## Background / problem

The [2026-08-31 OpenRewrite vulnerability report](https://github.com/moderneinc/dependency-vulnerability-reports/issues/1161) flags this project with eight Apache Camel advisories, one of them CRITICAL: CVE-2026-71300, CVE-2026-78329, CVE-2026-66906, CVE-2026-66907, CVE-2026-66908, CVE-2026-59230, CVE-2026-60093 and CVE-2026-63621. Every one of them names a specific `org.apache.camel:camel-<component>` module as its affected package. The artifact flagged here is `org.apache.camel.upgrade:camel-upgrade-recipes`, a different groupId that no advisory lists. It is the OpenRewrite recipe artifact that migrates user code between Camel versions, it ships no Camel runtime code, and it reaches this project shaded into rewrite-third-party.

The same suppression has been in `rewrite-build-gradle-plugin/src/main/resources/suppressions.xml` since 2026-07-13, and in rewrite-logging-frameworks and rewrite-third-party. It never reached this project because rewrite-recipe-bom does not delegate to the build plugin's shared suppression file, so this is a coverage gap rather than a new finding.

## Solution

Adds that reference-only suppression to this repo's own `suppressions.xml`, scoped to the `camel-upgrade-recipes` packageUrl and the `cpe:/a:apache:camel` identity, expiring 2026-10-01.

Also reported upstream as dependency-check/DependencyCheck#8780. The expiry lines up with that: if the fix ships in dependency-check's bundled base suppressions before then, the block simply goes away in the monthly cleanup.

## Test plan

- [x] `xmllint --noout suppressions.xml` passes
- [ ] Next scheduled vulnerability scan no longer reports the eight Camel CVEs against this project
