### PR TITLE
Renew lapsed Kotlin and jackson-databind suppressions to 2026-10-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -185,7 +185,7 @@
         <cve>CVE-2009-2719</cve>
         <cve>CVE-2009-2720</cve>
     </suppress>
-    <suppress until="2026-09-01Z">
+    <suppress until="2026-10-01Z">
         <notes><![CDATA[
        CVE-2026-53914 is unsafe deserialization of untrusted Kotlin build-cache
        metadata, allowing code execution (fixed in Kotlin 2.4.20). It requires local
@@ -194,15 +194,16 @@
        daemon, script-runtime, stdlib, reflect, etc.) here arrive transitively via the
        rewrite-kotlin recipe module; the vulnerable build-cache deserialization path
        lives in the Kotlin Gradle plugin / build tooling, not in these libraries, and
-       is not exercised. No GA toolchain at 2.4.20 has been released yet (as of
-       2026-08-03 Maven Central has only 2.4.20-Beta2), so there is nothing to bump to.
-       Re-evaluate when 2.4.20 goes GA.
+       is not exercised. GHSA-r937-wjx7-w2jp scopes the advisory to
+       org.jetbrains.kotlin:kotlin-gradle-plugin < 2.4.20-Beta1; none of the artifacts
+       flagged here is that plugin. Still no GA toolchain to bump to: as of 2026-09-01
+       Maven Central's newest is 2.4.20-RC2. Re-evaluate when 2.4.20 goes GA.
        Added: 2026-07-03
        ]]></notes>
        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*@.*$</packageUrl>
         <cve>CVE-2026-53914</cve>
     </suppress>
-    <suppress until="2026-09-01Z">
+    <suppress until="2026-10-01Z">
         <notes><![CDATA[
        jackson-databind polymorphic-typing / deserialization advisories:
        CVE-2026-54512 (PolymorphicTypeValidator bypass via generic type parameters),


### PR DESCRIPTION
## Background / problem

- Two suppressions in this file carried `until="2026-09-01Z"` and lapsed today, so the next vulnerability scan surfaces both again. The Kotlin one is the louder of the two: it reappears as a CRITICAL against `org.jetbrains.kotlin:*` across roughly 58 repositories in the [OpenRewrite report](https://github.com/moderneinc/dependency-vulnerability-reports/issues/1161).

Neither has become actionable since it was written. CVE-2026-53914 is GHSA-r937-wjx7-w2jp, scoped to `org.jetbrains.kotlin:kotlin-gradle-plugin` below 2.4.20-Beta1, and none of the artifacts flagged here is that plugin. It is also MODERATE at CVSS 6.7 rather than the CRITICAL the scanner reports. There is still nothing to bump to, since Maven Central's newest Kotlin is 2.4.20-RC2. The four jackson-databind advisories still require polymorphic typing on attacker-controlled input, and jackson remains centrally managed via rewrite-core.

The org-wide `UpdateOwaspSuppressionDate` run that renewed these same CVEs elsewhere did not reach this repository, so it needs doing by hand here.

## Solution

Moves both blocks to `until="2026-10-01Z"`, keeping the 1st-of-month convention so they expire together and get swept by the monthly `RemoveOwaspSuppressions` cleanup.

Also refreshes the Kotlin note, which still cited 2.4.20-Beta2 as the newest available build from 2026-08-03, and adds the advisory's actual affected artifact so the next triager does not re-derive it.

## Test plan

- [x] `xmllint --noout suppressions.xml` passes
- [ ] Next scheduled vulnerability scan no longer reports CVE-2026-53914 or the jackson-databind advisories against this project
